### PR TITLE
No subshell

### DIFF
--- a/bin/makecert.sh
+++ b/bin/makecert.sh
@@ -6,9 +6,9 @@ then
 fi
 
 # Check for jinja2 
-command -v jinja2 >/dev/null 2>&1 || { echo >&2 "This scripts requires jinja2-cli but it's not installed. Install with `pip install jinja2-cli`.  Aborting."; exit 1; }
+command -v jinja2 >/dev/null 2>&1 || { echo >&2 "This scripts requires jinja2-cli but it's not installed. Install with \`pip install jinja2-cli\`.  Aborting."; exit 1; }
 # Check for svg2pdf
-command -v svg2pdf>/dev/null 2>&1 || { echo >&2 "This script requires svg2pdf, a part of svglib. Install with `pip install svgilib`. Aborting."; exit 1; }
+command -v svg2pdf>/dev/null 2>&1 || { echo >&2 "This script requires svg2pdf, a part of svglib. Install with \`pip install svgilib\`. Aborting."; exit 1; }
 
 source_svg=${1}
 context=${2} 

--- a/bin/makecert.sh
+++ b/bin/makecert.sh
@@ -8,7 +8,7 @@ fi
 # Check for jinja2 
 command -v jinja2 >/dev/null 2>&1 || { echo >&2 "This scripts requires jinja2-cli but it's not installed. Install with \`pip install jinja2-cli\`.  Aborting."; exit 1; }
 # Check for svg2pdf
-command -v svg2pdf>/dev/null 2>&1 || { echo >&2 "This script requires svg2pdf, a part of svglib. Install with \`pip install svgilib\`. Aborting."; exit 1; }
+command -v svg2pdf>/dev/null 2>&1 || { echo >&2 "This script requires svg2pdf, a part of svglib. Install with \`pip install svglib\`. Aborting."; exit 1; }
 
 source_svg=${1}
 context=${2} 


### PR DESCRIPTION
The strings for two error messages contained syntax to open subshells, as the author used markdown syntax for inline code spans without escaping the backquotes.

The second commit fixes a typo in a package name.